### PR TITLE
Added dunder for importing as module

### DIFF
--- a/bip39.py
+++ b/bip39.py
@@ -2198,4 +2198,5 @@ bip39wordlist = [
     "zoo"
 ]
 
-main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The `main()` wont execute if code was imported as module. This helps to use mnemonics in different projects!